### PR TITLE
Test GitHub Action worfklow for Pint

### DIFF
--- a/.github/pint/pint.hcl
+++ b/.github/pint/pint.hcl
@@ -8,7 +8,7 @@ prometheus "mastering-prometheus-public" {
 }
 
 ci {
-  include = [ "ch12/rules/test-rule.yaml" ]
+  include = [ ".github/pint/test-rule.yaml" ]
   baseBranch = "main"
 }
 

--- a/.github/pint/test-rule.yaml
+++ b/.github/pint/test-rule.yaml
@@ -1,0 +1,16 @@
+groups:
+  - name: chapter12
+    rules:
+      # pint disable promql/series(probe_success)
+      - alert: SSHDown
+        expr: >
+          max_over_time(
+            probe_success{job="blackbox_ssh"}[5m]
+          ) != 1
+        for: 5m
+        labels:
+          severity: warning
+          team: sre
+        annotations:
+          description: "Cannot SSH to {{ $labels.instance }}"
+          grafana: https://grafana.example.com/ssh-dashboard?var-instance={{ $labels.instance }}

--- a/.github/workflows/pint.yaml
+++ b/.github/workflows/pint.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - "main"
     paths:
-      - "ch12/rules/*.yaml"
+      - ".github/pint/test-rule.yaml"
 
 
 jobs:


### PR DESCRIPTION
This is an example PR showing what Pint looks like when it is run within a GitHub Action and raises issues.